### PR TITLE
Bugfix: Add Javascript engine to run Uglifier and temporal fix for DB migration problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,13 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV HERALD_USER herald
 ENV HERALD_USER_ID 442
 ENV HERALD_HOMEDIR /home/$HERALD_USER
+ENV HERALD_VERSION '0.8.1'
 
 RUN apt-get update
-RUN apt-get install -y ruby libpq-dev ruby-dev make gcc postgresql-client
-RUN gem install puppet-herald -v '0.8.1'
+RUN apt-get install -y ruby libpq-dev ruby-dev make gcc g++ postgresql-client
+RUN gem install puppet-herald --version $HERALD_VERSION
 RUN gem install pg puma
+RUN gem install therubyracer
 
 RUN useradd --system --create-home --uid $HERALD_USER_ID --home-dir $HERALD_HOMEDIR $HERALD_USER
 RUN mkdir /etc/pherald
@@ -22,4 +24,6 @@ COPY src/herald_start.sh /usr/local/sbin/herald-start
 RUN chmod +x /usr/local/sbin/herald-start
 
 USER $HERALD_USER
+# TODO: Remove this when GH:wavesoftware/gem-puppet-herald#25 gets resolved
+WORKDIR /var/lib/gems/1.9.1/gems/puppet-herald-$HERALD_VERSION
 CMD ["/usr/local/sbin/herald-start"]

--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 [![Build Status](https://travis-ci.org/coi-gov-pl/docker-herald.svg?branch=develop)](https://travis-ci.org/coi-gov-pl/docker-herald)
 
-This is a container that holds a Herald app inside the Docker container. More info about the application and how to use it with Puppet are available on https://github.com/wavesoftware/gem-puppet-herald/blob/develop/README.md
+This is a Docker container that holds a Herald app inside. Herald is a puppet report processor that provides a gateway for consuming puppet reports, a REST API and a simple Web app to display them.
+
+![A reports list](https://raw.githubusercontent.com/wavesoftware/gem-puppet-herald/gh-pages/images/reports.png)
+
+More info about the application and how to use it with Puppet are available on repo page: https://github.com/wavesoftware/gem-puppet-herald
 
 ## Overview
 
-A docker image to run Herald tool on any Dockerized host: Linux, Mac or Windows. It utilize PostgreSQL as a database containing Puppet reports. While application stats it will try to migrate database to desired state.
+A docker image to run Herald app on any Docker host: Linux, Mac or Windows. It utilize PostgreSQL as a database containing Puppet reports. While application stats it will try to migrate database to desired state.
 
 ## Configuration
 


### PR DESCRIPTION
I've made a quick fix to add embedded Javascript engine that is needed for uglifier gem. It is also mentioned in issue wavesoftware/gem-puppet-herald#23

I've also set workdir to `/var/lib/gems/1.9.1/gems/puppet-herald-$HERALD_VERSION` to walk around a bug wavesoftware/gem-puppet-herald#25 (This should be removed after it gets fixed, probably in release [v0.8.2](https://github.com/wavesoftware/gem-puppet-herald/milestones/v0.8.2%20-%20WildLemon))

As a bonus: couple of minor fixes to README
